### PR TITLE
Add postinstall script to run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json && cp teleproto/tl/generated/api.js dist/tl/generated/api.js && cp teleproto/tl/generated/api.d.ts dist/tl/generated/api.d.ts",
     "typecheck": "tsc --noEmit",
-    "postinstall": "npm install && npm run build",
+    "postinstall": "npm run build",
     "generate:tl": "ts-node --transpile-only teleproto_generator/generate.ts",
     "publish:dist-manifest": "node -e \"const fs=require('fs');const pkg=require('./package.json');const out={name:pkg.name,version:pkg.version,description:pkg.description,main:pkg.main,types:pkg.types,repository:pkg.repository,license:pkg.license,bugs:pkg.bugs,keywords:pkg.keywords,homepage:pkg.homepage,dependencies:pkg.dependencies};fs.writeFileSync('dist/package.json',JSON.stringify(out,null,2)+'\\n');\"",
     "publish:prepare": "npm run clean && npm run generate:tl && npm run build && npm run typecheck && npm run publish:dist-manifest && cp README.md LICENSE.txt dist/ && cp teleproto/define.d.ts dist/define.d.ts && cp teleproto/tl/generated/api.js dist/tl/generated/api.js && cp teleproto/tl/generated/api.d.ts dist/tl/generated/api.d.ts && rm -f dist/tsconfig.tsbuildinfo",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json && cp teleproto/tl/generated/api.js dist/tl/generated/api.js && cp teleproto/tl/generated/api.d.ts dist/tl/generated/api.d.ts",
     "typecheck": "tsc --noEmit",
+    "postinstall": "npm run build",
     "generate:tl": "ts-node --transpile-only teleproto_generator/generate.ts",
     "publish:dist-manifest": "node -e \"const fs=require('fs');const pkg=require('./package.json');const out={name:pkg.name,version:pkg.version,description:pkg.description,main:pkg.main,types:pkg.types,repository:pkg.repository,license:pkg.license,bugs:pkg.bugs,keywords:pkg.keywords,homepage:pkg.homepage,dependencies:pkg.dependencies};fs.writeFileSync('dist/package.json',JSON.stringify(out,null,2)+'\\n');\"",
     "publish:prepare": "npm run clean && npm run generate:tl && npm run build && npm run typecheck && npm run publish:dist-manifest && cp README.md LICENSE.txt dist/ && cp teleproto/define.d.ts dist/define.d.ts && cp teleproto/tl/generated/api.js dist/tl/generated/api.js && cp teleproto/tl/generated/api.d.ts dist/tl/generated/api.d.ts && rm -f dist/tsconfig.tsbuildinfo",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json && cp teleproto/tl/generated/api.js dist/tl/generated/api.js && cp teleproto/tl/generated/api.d.ts dist/tl/generated/api.d.ts",
     "typecheck": "tsc --noEmit",
-    "postinstall": "npm run build",
+    "postinstall": "npm install && npm run build",
     "generate:tl": "ts-node --transpile-only teleproto_generator/generate.ts",
     "publish:dist-manifest": "node -e \"const fs=require('fs');const pkg=require('./package.json');const out={name:pkg.name,version:pkg.version,description:pkg.description,main:pkg.main,types:pkg.types,repository:pkg.repository,license:pkg.license,bugs:pkg.bugs,keywords:pkg.keywords,homepage:pkg.homepage,dependencies:pkg.dependencies};fs.writeFileSync('dist/package.json',JSON.stringify(out,null,2)+'\\n');\"",
     "publish:prepare": "npm run clean && npm run generate:tl && npm run build && npm run typecheck && npm run publish:dist-manifest && cp README.md LICENSE.txt dist/ && cp teleproto/define.d.ts dist/define.d.ts && cp teleproto/tl/generated/api.js dist/tl/generated/api.js && cp teleproto/tl/generated/api.d.ts dist/tl/generated/api.d.ts && rm -f dist/tsconfig.tsbuildinfo",

--- a/teleproto/events/CallbackQuery.ts
+++ b/teleproto/events/CallbackQuery.ts
@@ -155,7 +155,7 @@ export class CallbackQueryEvent extends EventCommonSender {
         this._inputSender = inputSender;
     }
 
-    get id() {
+    get id(): bigInt.BigInteger {
         return this.query.queryId;
     }
 

--- a/teleproto/extensions/BinaryReader.ts
+++ b/teleproto/extensions/BinaryReader.ts
@@ -50,7 +50,7 @@ export class BinaryReader {
      * @param signed
      * @returns {BigInteger}
      */
-    readLong(signed = true) {
+    readLong(signed = true): bigInt.BigInteger {
         return this.readLargeInt(64, signed);
     }
 

--- a/teleproto/tl/custom/chatGetter.ts
+++ b/teleproto/tl/custom/chatGetter.ts
@@ -81,7 +81,7 @@ export class ChatGetter {
         return this._inputChat;
     }
 
-    get chatId() {
+    get chatId(): bigInt.BigInteger | undefined {
         return this._chatPeer
             ? returnBigInt(getPeerId(this._chatPeer))
             : undefined;

--- a/teleproto/tl/custom/file.ts
+++ b/teleproto/tl/custom/file.ts
@@ -62,7 +62,7 @@ export class File {
         return this._fromAttr(Api.DocumentAttributeSticker, "stickerset");
     }
 
-    get size() {
+    get size(): bigInt.BigInteger | undefined | number {
         if (this.media instanceof Api.Photo) {
             return _photoSizeByteCount(
                 this.media.sizes[this.media.sizes.length - 1]


### PR DESCRIPTION
This PR adds a `postinstall` script to `package.json` to automate the build process.

Currently, when users install this package directly from GitHub (e.g., via `npm install sanyok12345/teleproto`), the `dist` folder is missing because it is excluded by .gitignore. This prevents the package from working immediately after installation.

By adding `"postinstall": "npm run build"`, the package will automatically compile the source code into the `dist` directory upon installation, ensuring a seamless experience for developers using the GitHub version.